### PR TITLE
invalid field "inputBinding" in inputs section of a workflow

### DIFF
--- a/base_quality_recalibration/base_quality_recalibration.cwl
+++ b/base_quality_recalibration/base_quality_recalibration.cwl
@@ -24,16 +24,12 @@ inputs:
       - 'null'
       - type: array
         items: string
-        inputBinding:
-          prefix: '--read-filter'
     'sbg:x': 0
     'sbg:y': 213.375
   - id: known_sites
     type:
       type: array
       items: File
-      inputBinding:
-        prefix: '--known-sites'
     secondaryFiles:
       - .idx
     'sbg:x': 0
@@ -51,8 +47,6 @@ inputs:
       - 'null'
       - type: array
         items: string
-        inputBinding:
-          prefix: '--disable-read-filter'
     'sbg:x': 0
     'sbg:y': 640.0625
   - id: lenient


### PR DESCRIPTION
`inputBinding` only makes sense in a CommandLineTool, not a Workflow

https://cwl.discourse.group/t/cwltool-pack-invalid-field-inputbinding/358/3