### PR TITLE
Variant annot vcf2maf ref fasta

### DIFF
--- a/variant_annotation/README.md
+++ b/variant_annotation/README.md
@@ -10,14 +10,27 @@
 #### Usage
 
 ```bash
-usage: variant_annotation.cwl [-h] --input_DB_vcf INPUT_DB_VCF --input_vcf
-                              INPUT_VCF --input_DB_vcf_1 INPUT_DB_VCF_1
-                              [--min_hom_vaf MIN_HOM_VAF]
-                              [--output_maf OUTPUT_MAF]
-                              [--ref_fasta REF_FASTA]
-                              [--retain_info RETAIN_INFO]
-                              [--tumor_id TUMOR_ID]
-                              [job_order]
+usage: variant_annotation.cwl [-h]  --input_cosmicCountDB_vcf INPUT_COSMICCOUNTDB_VCF
+       --vardict_input_vcf VARDICT_INPUT_VCF --input_cosmicprevalenceDB_vcf
+       INPUT_COSMICPREVALENCEDB_VCF [--min_hom_vaf MIN_HOM_VAF]
+       [--output_mafName OUTPUT_MAFNAME] [--retain_info RETAIN_INFO]
+       [--tumor_id TUMOR_ID] [--snpsift_countOpName SNPSIFT_COUNTOPNAME]
+       [--snpsift_prevalOpName SNPSIFT_PREVALOPNAME]
+       [job_order]
 
+positional arguments:
+  job_order             Job input json file
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --input_cosmicCountDB_vcf INPUT_COSMICCOUNTDB_VCF
+  --vardict_input_vcf VARDICT_INPUT_VCF
+  --input_cosmicprevalenceDB_vcf INPUT_COSMICPREVALENCEDB_VCF
+  --min_hom_vaf MIN_HOM_VAF
+  --output_mafName OUTPUT_MAFNAME
+  --retain_info RETAIN_INFO
+  --tumor_id TUMOR_ID
+  --snpsift_countOpName SNPSIFT_COUNTOPNAME
+  --snpsift_prevalOpName SNPSIFT_PREVALOPNAME
 ```
 

--- a/variant_annotation/example_inputs.yaml
+++ b/variant_annotation/example_inputs.yaml
@@ -1,34 +1,17 @@
-bedfile_for_vardict:
+vardict_input_vcf:
+  class: File
+  path: /path/to/vardict_concat.vcf.gz
+input_cosmicCountDB_vcf:
   class: File
   path: >-
-    /path/to/bed/file.bed
-concatvcf_output_name: concat.vcf.gz
-custom_enst:
+    /work/cch/production/resources/cosmic/versions/v96/CosmicCodingMuts.vcf.gz
+input_cosmicprevalenceDB_vcf:
   class: File
   path: >-
-    /path/to/overridesFile
-input_bam_case:
-  class: File
-  path: >-
-    /path/to/CHbam/file.bam
-input_vcf_cosmicDB:
-  class: File
-  path: >-
-    /path/to/cosmicDB/file.vcf.gz
-input_vcf_preval:
-  class: File
-  path: >-
-    /path/to/cosmicPrevalance
-output_file_name_cosmicdb: snpsift_cosmic.vcf
-output_file_name_preval: snpsift_preval.vcf
-output_maf_name: annotated.maf
-reference_fasta:
-  class:File
-  path : >-
-    /path/to/reference/file.fa
-retain_fmt: null
-retain_info: null
-sample_name: null
-stdout: TRUE
-vardict_output_vcf_name: filename.vcf
-vcf_tumor_id: tumorID
+    /work/cch/production/resources/cosmic/versions/v96/CosmicCodingMuts_GRCh37_processed.vcf.gz
+snpsift_countOpName: tumorId_cosmic.vcf
+snpsift_prevalOpName: tumorId_preval.vcf
+output_mafName: tumorId_annotated.maf
+retain_info: CNT,TUMOR_TYPE
+tumor_id: tumorId
+min_hom_vaf: 0

--- a/variant_annotation/variant_annotation.cwl
+++ b/variant_annotation/variant_annotation.cwl
@@ -6,7 +6,7 @@ $namespaces:
   s: 'https://schema.org/'
   sbg: 'https://www.sevenbridges.com/'
 inputs:
-  - id: input_cosmicCount_vcf
+  - id: input_cosmicCountDB_vcf
     type: File
     'sbg:x': 0
     'sbg:y': 434.1875
@@ -16,8 +16,8 @@ inputs:
     'sbg:y': 327.390625
   - id: input_cosmicprevalence_vcf
     type: File
-    'sbg:x': 155.640625
-    'sbg:y': 434.1875
+    'sbg:x': 217.47328186035156
+    'sbg:y': 564.6259765625
   - id: min_hom_vaf
     type: float?
     'sbg:x': 416.7921447753906
@@ -34,10 +34,6 @@ inputs:
     type: string?
     'sbg:x': 416.7921447753906
     'sbg:y': 0
-  - id: ref_fasta
-    type: string?
-    'sbg:x': 750.5759887695312
-    'sbg:y': 511.7911376953125
   - id: snpsift_countOpName
     type: string?
     'sbg:x': 16.4202823638916
@@ -69,7 +65,7 @@ steps:
   - id: snpsift_annotate_5_0
     in:
       - id: input_DB_vcf
-        source: input_cosmicCount_vcf
+        source: input_cosmicCountDB_vcf
       - id: input_vcf
         source: vardict_input_vcf
       - id: output_file_name
@@ -104,7 +100,6 @@ steps:
         source: output_mafName
       - id: ref_fasta
         default: /.vep/homo_sapiens/105_GRCh37/Homo_sapiens.GRCh37.dna.toplevel.fa.gz
-        source: ref_fasta
       - id: retain_info
         source: retain_info
       - id: tumor_id

--- a/variant_annotation/variant_annotation.cwl
+++ b/variant_annotation/variant_annotation.cwl
@@ -35,9 +35,9 @@ inputs:
     'sbg:x': 416.7921447753906
     'sbg:y': 0
   - id: ref_fasta
-    type: File?
-    'sbg:x': 766.7887573242188
-    'sbg:y': 565.2807006835938
+    type: string?
+    'sbg:x': 750.5759887695312
+    'sbg:y': 511.7911376953125
 outputs:
   - id: cosmicCount_annotatedOutput
     outputSource:
@@ -91,6 +91,7 @@ steps:
       - id: output_maf
         source: output_maf
       - id: ref_fasta
+        default: '/.vep/homo_sapiens/105_GRCh37/Homo_sapiens.GRCh37.dna.toplevel.fa.gz'
         source: ref_fasta
       - id: retain_info
         source: retain_info

--- a/variant_annotation/variant_annotation.cwl
+++ b/variant_annotation/variant_annotation.cwl
@@ -22,7 +22,7 @@ inputs:
     type: float?
     'sbg:x': 416.7921447753906
     'sbg:y': 654.78125
-  - id: output_maf
+  - id: output_mafName
     type: string?
     'sbg:x': 416.7921447753906
     'sbg:y': 441.1875
@@ -38,13 +38,21 @@ inputs:
     type: string?
     'sbg:x': 750.5759887695312
     'sbg:y': 511.7911376953125
+  - id: snpsift_countOpName
+    type: string?
+    'sbg:x': 16.4202823638916
+    'sbg:y': 169.89190673828125
+  - id: snpsift_prevalOpName
+    type: string?
+    'sbg:x': 214.9839324951172
+    'sbg:y': -51.58765411376953
 outputs:
   - id: cosmicCount_annotatedOutput
     outputSource:
       - snpsift_annotate_5_0/annotatedOutput
     type: File
-    'sbg:x': 416.7921447753906
-    'sbg:y': 761.578125
+    'sbg:x': 348.4152526855469
+    'sbg:y': 772.9266967773438
   - id: annotatedOutput_prevalence
     outputSource:
       - snpsift_annotate_5_1/annotatedOutput
@@ -64,6 +72,8 @@ steps:
         source: input_cosmicCount_vcf
       - id: input_vcf
         source: vardict_input_vcf
+      - id: output_file_name
+        source: snpsift_countOpName
     out:
       - id: annotatedOutput
     run: ../command_line_tools/snpsift_annotate_5.0/snpsift_annotate_5-0.cwl
@@ -76,6 +86,8 @@ steps:
         source: input_cosmicprevalence_vcf
       - id: input_vcf
         source: snpsift_annotate_5_0/annotatedOutput
+      - id: output_file_name
+        source: snpsift_prevalOpName
     out:
       - id: annotatedOutput
     run: ../command_line_tools/snpsift_annotate_5.0/snpsift_annotate_5-0.cwl
@@ -89,9 +101,9 @@ steps:
       - id: min_hom_vaf
         source: min_hom_vaf
       - id: output_maf
-        source: output_maf
+        source: output_mafName
       - id: ref_fasta
-        default: '/.vep/homo_sapiens/105_GRCh37/Homo_sapiens.GRCh37.dna.toplevel.fa.gz'
+        default: /.vep/homo_sapiens/105_GRCh37/Homo_sapiens.GRCh37.dna.toplevel.fa.gz
         source: ref_fasta
       - id: retain_info
         source: retain_info

--- a/variant_annotation/variant_annotation.cwl
+++ b/variant_annotation/variant_annotation.cwl
@@ -14,7 +14,7 @@ inputs:
     type: File
     'sbg:x': 0
     'sbg:y': 327.390625
-  - id: input_cosmicprevalence_vcf
+  - id: input_cosmicprevalenceDB_vcf
     type: File
     'sbg:x': 217.47328186035156
     'sbg:y': 564.6259765625
@@ -79,7 +79,7 @@ steps:
   - id: snpsift_annotate_5_1
     in:
       - id: input_DB_vcf
-        source: input_cosmicprevalence_vcf
+        source: input_cosmicprevalenceDB_vcf
       - id: input_vcf
         source: snpsift_annotate_5_0/annotatedOutput
       - id: output_file_name

--- a/variant_annotation/variant_annotation.cwl
+++ b/variant_annotation/variant_annotation.cwl
@@ -8,6 +8,8 @@ $namespaces:
 inputs:
   - id: input_cosmicCountDB_vcf
     type: File
+    secondaryFiles:
+      - .tbi
     'sbg:x': 0
     'sbg:y': 434.1875
   - id: vardict_input_vcf
@@ -16,6 +18,8 @@ inputs:
     'sbg:y': 327.390625
   - id: input_cosmicprevalenceDB_vcf
     type: File
+    secondaryFiles:
+      - .tbi
     'sbg:x': 217.47328186035156
     'sbg:y': 564.6259765625
   - id: min_hom_vaf


### PR DESCRIPTION
@rhshah  vcf2maf section inside variant annotation script is updated with ref fasta type. Example Input and the readme are also updated. 